### PR TITLE
Add no_std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "wtf8"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Implementation of the WTF-8 encoding. https://simonsapin.github.io/wtf-8/"
@@ -14,3 +14,7 @@ license = "MIT"
 [lib]
 name = "wtf8"
 doctest = false
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ rust-wtf8
 Implementation of [the WTF-8 encoding](https://simonsapin.github.io/wtf-8/).
 
 [Documentation](https://simonsapin.github.io/rust-wtf8/wtf8/index.html)
+
+
+=========
+This crate depends on the standard library by default, but can optionally depend on `core`, `collections`, and `rustc_unicode` by using `default-features = false` in your Cargo.toml as shown below:
+```
+[dependencies]
+wtf8 = { version = "0.0.3", default-features = false }
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,53 @@ WTF-8 strings can be obtained from UTF-8, UTF-16, or code points.
 
 */
 
+#![cfg_attr(not(feature = "std"), feature(collections, unicode))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate collections;
+#[cfg(not(feature = "std"))]
+extern crate rustc_unicode;
+
+#[cfg(not(feature = "std"))]
+use collections::{String, Vec};
+#[cfg(not(feature = "std"))]
+use core::str;
+#[cfg(not(feature = "std"))]
+use collections::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use core::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::hash;
+#[cfg(not(feature = "std"))]
+use core::iter::{FromIterator, IntoIterator};
+#[cfg(not(feature = "std"))]
+use core::mem::transmute;
+#[cfg(not(feature = "std"))]
+use core::ops::Deref;
+#[cfg(not(feature = "std"))]
+use collections::slice;
+
+#[cfg(feature = "std")]
 use std::str;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(feature = "std")]
 use std::cmp::Ordering;
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::hash;
+#[cfg(feature = "std")]
 use std::iter::{FromIterator, IntoIterator};
+#[cfg(feature = "std")]
 use std::mem::transmute;
+#[cfg(feature = "std")]
 use std::ops::Deref;
+#[cfg(feature = "std")]
 use std::slice;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::hash;
 use std::iter::{FromIterator, IntoIterator};
-use std::io::Write;
 use std::mem::transmute;
 use std::ops::Deref;
 use std::slice;
@@ -323,8 +322,9 @@ impl Wtf8Buf {
             match self.next_surrogate(pos) {
                 Some((surrogate_pos, _)) => {
                     pos = surrogate_pos + 3;
-                    (&mut self.bytes[surrogate_pos..pos])
-                        .write_all(UTF8_REPLACEMENT_CHARACTER).unwrap();
+                    for (i, val) in (&mut self.bytes[surrogate_pos..pos]).into_iter().enumerate() {
+                        *val = UTF8_REPLACEMENT_CHARACTER[i]
+                    }
                 },
                 None => return unsafe { String::from_utf8_unchecked(self.bytes) }
             }

--- a/src/not_quite_std.rs
+++ b/src/not_quite_std.rs
@@ -8,9 +8,20 @@
 //! try to avoid the code duplication.
 //! Maybe by having private generic code that is monomorphized to UTF-8 and WTF-8?
 
+#[cfg(not(feature = "std"))]
+use rustc_unicode::char;
+#[cfg(not(feature = "std"))]
+use core::mem;
+#[cfg(not(feature = "std"))]
+use collections::slice;
+
+#[cfg(feature = "std")]
 use std::char;
+#[cfg(feature = "std")]
 use std::mem;
+#[cfg(feature = "std")]
 use std::slice;
+
 use super::{Wtf8Buf, Wtf8, CodePoint, IllFormedUtf16CodeUnits};
 
 // UTF-8 ranges and tags for encoding characters


### PR DESCRIPTION
I'm writing [a library](https://github.com/FenrirWolf/ctru-rs) that interfaces with the Nintendo 3DS. Apparently the system uses the same UTF-16/UCS-2 hybrid as Windows for its internal string APIs, so I figured that WTF8 would be useful for making implementations of OsString, file paths, etc.

The Rust standard library is not available for the Nintendo 3DS, so this PR allows users to opt out of depending on libstd and instead depend on core/collections/rustc_unicode. The opt-out feature would only be usable from nightly Rust, but it should not interfere with normal stable use of the library.
