### PR TITLE
Add #[repr(transparent)] to Wtf8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,7 @@ impl Extend<CodePoint> for Wtf8Buf {
 ///
 /// Similar to `&str`, but can additionally contain surrogate code points
 /// if they’re not in a surrogate pair.
+#[repr(transparent)]
 pub struct Wtf8 {
     bytes: [u8]
 }


### PR DESCRIPTION
Without this, I think the transmutes from `&[u8]` to `&Wtf8` could cause UB.